### PR TITLE
Use print() function in Python 3

### DIFF
--- a/recommendation/Basic-DIEN-Demo/source_code/local_aggretor.py
+++ b/recommendation/Basic-DIEN-Demo/source_code/local_aggretor.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import hashlib
 import random
@@ -37,7 +38,7 @@ for line in fin:
         if len(cat_str) > 0: cat_str = cat_str[:-1]
         if len(mid_str) > 0: mid_str = mid_str[:-1]
         if history_clk_num >= 1:    # 8 is the average length of user behavior
-            print >> fo, items[1] + "\t" + user + "\t" + movie_id + "\t" + cat1 +"\t" + mid_str + "\t" + cat_str
+            print(items[1] + "\t" + user + "\t" + movie_id + "\t" + cat1 +"\t" + mid_str + "\t" + cat_str, file=fo)
     last_user = user
     if clk:
         movie_id_list.append(movie_id)

--- a/recommendation/Basic-DIEN-Demo/source_code/process_data.py
+++ b/recommendation/Basic-DIEN-Demo/source_code/process_data.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import random
 import time
@@ -8,7 +9,7 @@ def process_meta(file):
     for line in fi:
         obj = eval(line)
         cat = obj["categories"][0][-1]
-        print>>fo, obj["asin"] + "\t" + cat
+        print(obj["asin"] + "\t" + cat, file=fo)
 
 def process_reviews(file):
     fi = open(file, "r")
@@ -20,7 +21,7 @@ def process_reviews(file):
         itemID = obj["asin"]
         rating = obj["overall"]
         time = obj["unixReviewTime"]
-        print>>fo, userID + "\t" + itemID + "\t" + str(rating) + "\t" + str(time)
+        print(userID + "\t" + itemID + "\t" + str(rating) + "\t" + str(time), file=fo)
 
 def manual_join():
     f_rev = open("reviews-info", "r")
@@ -55,14 +56,14 @@ def manual_join():
                 if asin_neg == asin:
                     continue 
                 items[1] = asin_neg
-                print>>fo, "0" + "\t" + "\t".join(items) + "\t" + meta_map[asin_neg]
+                print("0" + "\t" + "\t".join(items) + "\t" + meta_map[asin_neg], file=fo)
                 j += 1
                 if j == 1:             #negative sampling frequency
                     break
             if asin in meta_map:
-                print>>fo, "1" + "\t" + line + "\t" + meta_map[asin]
+                print("1" + "\t" + line + "\t" + meta_map[asin], file=fo)
             else:
-                print>>fo, "1" + "\t" + line + "\t" + "default_cat"
+                print("1" + "\t" + line + "\t" + "default_cat", file=fo)
 
 
 def split_test():
@@ -83,16 +84,16 @@ def split_test():
         user = line.split("\t")[1]
         if user == last_user:
             if i < user_count[user] - 2:  # 1 + negative samples
-                print>> fo, "20180118" + "\t" + line
+                print("20180118" + "\t" + line, file=fo)
             else:
-                print>>fo, "20190119" + "\t" + line
+                print("20190119" + "\t" + line, file=fo)
         else:
             last_user = user
             i = 0
             if i < user_count[user] - 2:
-                print>> fo, "20180118" + "\t" + line
+                print("20180118" + "\t" + line, file=fo)
             else:
-                print>>fo, "20190119" + "\t" + line
+                print("20190119" + "\t" + line, file=fo)
         i += 1
 
 process_meta(sys.argv[1])

--- a/recommendation/Basic-DIEN-Demo/source_code/shuffle.py
+++ b/recommendation/Basic-DIEN-Demo/source_code/shuffle.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import random
@@ -12,7 +13,7 @@ def main(file, temporary=False):
 
     fd = open(file, "r")
     for l in fd:
-        print >> tf, l.strip("\n")
+        print(l.strip("\n"), file=tf)
     tf.close()
 
     lines = open(tpath, 'r').readlines()
@@ -25,7 +26,7 @@ def main(file, temporary=False):
 
     for l in lines:
         s = l.strip("\n")
-        print >> fd, s
+        print(s, file=fd)
 
     if temporary:
         fd.seek(0)

--- a/recommendation/Basic-DIEN-Demo/source_code/split_by_user.py
+++ b/recommendation/Basic-DIEN-Demo/source_code/split_by_user.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import random
 
 fi = open("local_test", "r")
@@ -11,10 +12,10 @@ while True:
     if noclk_line == "" or clk_line == "":
         break
     if rand_int == 2:
-        print >> ftest, noclk_line
-        print >> ftest, clk_line
+        print(noclk_line, file=ftest)
+        print(clk_line, file=ftest)
     else:
-        print >> ftrain, noclk_line
-        print >> ftrain, clk_line
+        print(noclk_line, file=ftrain)
+        print(clk_line, file=ftrain)
         
 


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.